### PR TITLE
Fix card expiration error message

### DIFF
--- a/src/gateway/API/Card.php
+++ b/src/gateway/API/Card.php
@@ -209,7 +209,7 @@
             }
 
             if (strlen($cardExpirationDate) >= 7) {
-                throw new Exception('setCardExpirationDate must be less than 7 characters - MMYYYY');
+                throw new Exception('setCardExpirationDate must be less than 7 characters - YYYYMM');
             }
 
             $this->cardExpirationDate = $cardExpirationDate;


### PR DESCRIPTION
Na documentação diz que o formato correto da data é `yyyymm`
